### PR TITLE
v1.6.1 - Added Uint8Array type mdn link for types.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # jsdoc-md changelog
 
+## Next
+
+### Minor
+
+- Updated dependencies.
+
 ## 1.6.0
 
 ### Minor

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Minor
 
 - Updated dependencies.
+- Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
 
 ## 1.6.0
 

--- a/cli.js
+++ b/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 const yargs = require('yargs')
-const jsdocMd = require('./lib/jsdocMd')
 const DEFAULTS = require('./lib/defaults')
+const jsdocMd = require('./lib/jsdocMd')
 
 const { argv } = yargs
   .options({

--- a/lib/getJsdocAstTag.test.js
+++ b/lib/getJsdocAstTag.test.js
@@ -1,5 +1,5 @@
-const t = require('tap')
 const doctrine = require('doctrine')
+const t = require('tap')
 const getJsdocAstTag = require('./getJsdocAstTag')
 
 t.test('getJsdocAstTag', t => {

--- a/lib/getJsdocAstTags.test.js
+++ b/lib/getJsdocAstTags.test.js
@@ -1,5 +1,5 @@
-const t = require('tap')
 const doctrine = require('doctrine')
+const t = require('tap')
 const getJsdocAstTags = require('./getJsdocAstTags')
 
 t.test('getJsdocAstTags', t => {

--- a/lib/jsdocMd.js
+++ b/lib/jsdocMd.js
@@ -1,10 +1,10 @@
 const { readFileSync } = require('fs')
 const globby = require('globby')
-const mdFileReplaceSection = require('./mdFileReplaceSection')
+const DEFAULTS = require('./defaults')
 const jsdocCommentsFromCode = require('./jsdocCommentsFromCode')
 const jsdocToMember = require('./jsdocToMember')
+const mdFileReplaceSection = require('./mdFileReplaceSection')
 const membersToMdAst = require('./membersToMdAst')
-const DEFAULTS = require('./defaults')
 
 /**
  * Scrapes JSDoc from files to populate a markdown file documentation section.

--- a/lib/jsdocToMember.js
+++ b/lib/jsdocToMember.js
@@ -1,6 +1,6 @@
 const doctrine = require('doctrine')
-const getJsdocAstTag = require('./getJsdocAstTag')
 const deconstructJsdocNamepath = require('./deconstructJsdocNamepath')
+const getJsdocAstTag = require('./getJsdocAstTag')
 
 /**
  * Converts a Doctrine JSDoc comment string to an outline member object.

--- a/lib/membersToMdAst.js
+++ b/lib/membersToMdAst.js
@@ -2,8 +2,8 @@ const toc = require('remark-toc')
 const unified = require('unified')
 const getJsdocAstTag = require('./getJsdocAstTag')
 const getJsdocAstTags = require('./getJsdocAstTags')
-const outlineMembers = require('./outlineMembers')
 const mdToMdAst = require('./mdToMdAst')
+const outlineMembers = require('./outlineMembers')
 const typeJsdocAstToMdAst = require('./typeJsdocAstToMdAst')
 
 const MEMBERSHIP_ORDER = ['.', '#', '~']
@@ -53,14 +53,13 @@ const membersToMdAst = (members, depth = 1) => {
    */
   const recurse = (members, depth) => {
     members
-      .sort(
-        (a, b) =>
-          a.membership !== b.membership
-            ? MEMBERSHIP_ORDER.indexOf(a.membership) -
-              MEMBERSHIP_ORDER.indexOf(b.membership)
-            : a.kind !== b.kind
-              ? KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind)
-              : a.name.localeCompare(b.name)
+      .sort((a, b) =>
+        a.membership !== b.membership
+          ? MEMBERSHIP_ORDER.indexOf(a.membership) -
+            MEMBERSHIP_ORDER.indexOf(b.membership)
+          : a.kind !== b.kind
+          ? KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind)
+          : a.name.localeCompare(b.name)
       )
       .forEach(member => {
         mdast.children.push({

--- a/lib/membersToMdAst.test.js
+++ b/lib/membersToMdAst.test.js
@@ -1,8 +1,8 @@
-const t = require('tap')
 const stringify = require('remark-stringify')
+const t = require('tap')
 const unified = require('unified')
-const membersToMdAst = require('./membersToMdAst')
 const jsdocToMember = require('./jsdocToMember')
+const membersToMdAst = require('./membersToMdAst')
 
 t.test('membersToMdAst', t => {
   t.throws(

--- a/lib/outlineMembers.js
+++ b/lib/outlineMembers.js
@@ -40,12 +40,12 @@ const outlineMembers = members => {
             member.kind === 'function' && member.membership !== '~'
               ? 'method'
               : member.kind === 'member'
-                ? 'property'
-                : member.kind
+              ? 'property'
+              : member.kind
           }`
         : member.kind === 'typedef'
-          ? 'type'
-          : member.kind
+        ? 'type'
+        : member.kind
     } ${member.name}`
 
     // Set the slug property.

--- a/lib/outlineMembers.test.js
+++ b/lib/outlineMembers.test.js
@@ -1,7 +1,7 @@
-const t = require('tap')
 const CircularJSON = require('circular-json')
-const outlineMembers = require('./outlineMembers')
+const t = require('tap')
 const jsdocToMember = require('./jsdocToMember')
+const outlineMembers = require('./outlineMembers')
 
 t.test('outlineMembers', t => {
   const members = [

--- a/lib/remarkPluginReplaceSection.test.js
+++ b/lib/remarkPluginReplaceSection.test.js
@@ -1,6 +1,5 @@
 const t = require('tap')
 const unified = require('unified')
-
 const remarkPluginReplaceSection = require('./remarkPluginReplaceSection')
 
 t.test('remarkPluginReplaceSection', t => {

--- a/lib/replaceJsdocLinks.test.js
+++ b/lib/replaceJsdocLinks.test.js
@@ -1,7 +1,7 @@
 const t = require('tap')
-const replaceJsdocLinks = require('./replaceJsdocLinks')
 const jsdocToMember = require('./jsdocToMember')
 const outlineMembers = require('./outlineMembers')
+const replaceJsdocLinks = require('./replaceJsdocLinks')
 
 t.test('replaceJsdocLinks', t => {
   const outlinedMembers = outlineMembers(

--- a/lib/typeJsdocAstToMdAst.js
+++ b/lib/typeJsdocAstToMdAst.js
@@ -111,14 +111,15 @@ const typeJsdocAstToMdAst = (typeJsdocAst, members) => {
 
       const lowercaseName = typeJsdocAst.name.toLowerCase()
       switch (lowercaseName) {
-        case 'boolean':
-        case 'number':
-        case 'string':
-        case 'function':
         case 'array':
-        case 'object':
+        case 'boolean':
         case 'date':
+        case 'function':
+        case 'number':
+        case 'object':
         case 'promise':
+        case 'string':
+        case 'uint8array':
           return [
             {
               type: 'link',

--- a/lib/typeJsdocAstToMdAst.test.js
+++ b/lib/typeJsdocAstToMdAst.test.js
@@ -1,11 +1,11 @@
-const t = require('tap')
 const doctrine = require('doctrine')
 const stringify = require('remark-stringify')
+const t = require('tap')
 const unified = require('unified')
-const typeJsdocAstToMdAst = require('./typeJsdocAstToMdAst')
-const remarkStringifyOptions = require('./remarkStringifyOptions')
-const outlineMembers = require('./outlineMembers')
 const jsdocToMember = require('./jsdocToMember')
+const outlineMembers = require('./outlineMembers')
+const remarkStringifyOptions = require('./remarkStringifyOptions')
+const typeJsdocAstToMdAst = require('./typeJsdocAstToMdAst')
 
 /**
  * Converts a type string to a markdown AST.

--- a/package.json
+++ b/package.json
@@ -64,8 +64,12 @@
     "test:eslint": "eslint .",
     "test:prettier": "prettier '**/*.{json,yml,md}' -l",
     "test:js": "tap ./lib/*.test.js -R spec",
-    "prepublishOnly": "npm run prepare && npm test",
-    "precommit": "lint-staged"
+    "prepublishOnly": "npm run prepare && npm test"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "*.js": "eslint",

--- a/package.json
+++ b/package.json
@@ -31,29 +31,30 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
-    "doctrine": "^2.1.0",
+    "@babel/core": "^7.1.6",
+    "doctrine": "^3.0.0",
     "github-slugger": "^1.2.0",
     "globby": "^8.0.1",
     "mdast-util-inject": "^1.1.0",
-    "remark-parse": "^5.0.0",
-    "remark-stringify": "^5.0.0",
-    "remark-toc": "^5.0.0",
-    "unified": "^7.0.0",
-    "yargs": "^12.0.1"
+    "remark-parse": "^6.0.3",
+    "remark-stringify": "^6.0.4",
+    "remark-toc": "^5.1.0",
+    "unified": "^7.0.2",
+    "yargs": "^12.0.4"
   },
   "devDependencies": {
-    "circular-json": "^0.5.5",
-    "eslint": "^5.3.0",
-    "eslint-config-env": "^1.0.0",
-    "eslint-config-prettier": "^3.0.1",
+    "circular-json": "^0.5.9",
+    "eslint": "^5.9.0",
+    "eslint-config-env": "^2.0.0",
+    "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^7.0.1",
-    "eslint-plugin-prettier": "^2.6.1",
-    "husky": "^0.14.3",
-    "lint-staged": "^7.2.2",
-    "prettier": "^1.14.2",
-    "tap": "^12.0.1"
+    "eslint-plugin-import-order-alphabetical": "0.0.1",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "husky": "^1.1.4",
+    "lint-staged": "^8.0.5",
+    "prettier": "^1.15.2",
+    "tap": "^12.1.0"
   },
   "scripts": {
     "prepare": "npm run prepare:jsdoc && npm run prepare:prettier",

--- a/tap-snapshots/lib-membersToMdAst.test.js-TAP.test.js
+++ b/tap-snapshots/lib-membersToMdAst.test.js-TAP.test.js
@@ -28,10 +28,12 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
     {
       "type": "list",
       "ordered": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
           "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "paragraph",
@@ -52,10 +54,12 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
             {
               "type": "list",
               "ordered": false,
+              "spread": false,
               "children": [
                 {
                   "type": "listItem",
                   "loose": false,
+                  "spread": false,
                   "children": [
                     {
                       "type": "paragraph",
@@ -78,6 +82,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
                 {
                   "type": "listItem",
                   "loose": false,
+                  "spread": false,
                   "children": [
                     {
                       "type": "paragraph",
@@ -100,6 +105,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
                 {
                   "type": "listItem",
                   "loose": false,
+                  "spread": false,
                   "children": [
                     {
                       "type": "paragraph",
@@ -122,6 +128,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
                 {
                   "type": "listItem",
                   "loose": false,
+                  "spread": false,
                   "children": [
                     {
                       "type": "paragraph",
@@ -148,6 +155,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
         {
           "type": "listItem",
           "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "paragraph",
@@ -170,6 +178,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
         {
           "type": "listItem",
           "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "paragraph",
@@ -192,6 +201,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
         {
           "type": "listItem",
           "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "paragraph",
@@ -214,6 +224,7 @@ exports[`lib/membersToMdAst.test.js TAP membersToMdAst > Markdown AST. 1`] = `
         {
           "type": "listItem",
           "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "paragraph",

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
-const { sep } = require('path')
-const { tmpdir } = require('os')
 const { writeFileSync, unlinkSync } = require('fs')
+const { tmpdir } = require('os')
+const { sep } = require('path')
 
 /**
  * Creates a temporary file that deletes at test teardown.


### PR DESCRIPTION
Things I have done.
1. Prettier styles /lib/membersToMdAst.js and /lib/outlineMembers.js.
2. Alphabetized the order of the mdn link types in [typeJsdocAstToMdAst](https://github.com/pur3miish/jsdoc-md/blob/master/lib/typeJsdocAstToMdAst.js#L114-L122)
3. Included `"spread": false` for [snapshots](https://github.com/pur3miish/jsdoc-md/blob/master/tap-snapshots/lib-membersToMdAst.test.js-TAP.test.js) as snapshot test were failing.

I hope it is all done correctly

Thanks