### PR TITLE
Mdast types includes Uint8Array.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Minor
+
+- [Uint8Array](https://mdn.io/uint8array) now MDN linked & alphabetized, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
+
 ### Patch
 
 - Updated dependencies.

--- a/changelog.md
+++ b/changelog.md
@@ -4,13 +4,12 @@
 
 ### Minor
 
-- [Uint8Array](https://mdn.io/uint8array) now MDN linked & alphabetized, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
+- Added MDN links for [`Uint8Array`](https://mdn.io/uint8array) types and updated snapshot tests, fixing [#11](https://github.com/jaydenseric/jsdoc-md/issues/9) via [#12](https://github.com/jaydenseric/jsdoc-md/pull/12).
 
 ### Patch
 
 - Updated dependencies.
 - Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
-- [Uint8Array](https://mdn.io/uint8array) now MDN linked & alphabetized, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
 - Added a missing test for the `Promise` type MDN link.
 
 ## 1.6.0

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@
 
 - Updated dependencies.
 - Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
-- [Uint8Array](https://mdn.io/uint8array) now MDN linked, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
+- [Uint8Array](https://mdn.io/uint8array) now MDN linked & alphabetized, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
+- Test added for `Promise` type MDN link & alphabetized order of tests.
 
 ## 1.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - Updated dependencies.
 - Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
 - [Uint8Array](https://mdn.io/uint8array) now MDN linked & alphabetized, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
-- Test added for `Promise` type MDN link & alphabetized order of tests.
+- Added a missing test for the `Promise` type MDN link.
 
 ## 1.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,9 @@
 
 ### Patch
 
-- Included mdn [Uint8Array](https://mdn.io/uint8array) type link.
-- Updated snapshot test for Uint8array type.
 - Updated dependencies.
 - Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
+- [Uint8Array](https://mdn.io/uint8array) now MDN linked, updated snapshot test for `Uint8Array` and fixed [#11](https://github.com/jaydenseric/jsdoc-md/issues/9).
 
 ## 1.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Patch
 
+- Included mdn [Uint8Array](https://mdn.io/uint8array) type link.
+- Updated snapshot test for Uint8array type.
 - Updated dependencies.
 - Updated package scripts and config for the new [`husky`](https://npm.im/husky) version.
 

--- a/lib/typeJsdocAstToMdAst.js
+++ b/lib/typeJsdocAstToMdAst.js
@@ -111,14 +111,14 @@ const typeJsdocAstToMdAst = (typeJsdocAst, members) => {
 
       const lowercaseName = typeJsdocAst.name.toLowerCase()
       switch (lowercaseName) {
-        case 'boolean':
-        case 'number':
-        case 'string':
-        case 'function':
         case 'array':
-        case 'object':
+        case 'boolean':
         case 'date':
+        case 'function':
+        case 'number':
+        case 'object':
         case 'promise':
+        case 'string':
         case 'uint8array':
           return [
             {

--- a/lib/typeJsdocAstToMdAst.js
+++ b/lib/typeJsdocAstToMdAst.js
@@ -119,6 +119,7 @@ const typeJsdocAstToMdAst = (typeJsdocAst, members) => {
         case 'object':
         case 'date':
         case 'promise':
+        case 'uint8array':
           return [
             {
               type: 'link',

--- a/lib/typeJsdocAstToMdAst.test.js
+++ b/lib/typeJsdocAstToMdAst.test.js
@@ -67,13 +67,14 @@ t.test('typeJsdocAstToMdAst', t => {
     // MDN link slug.
 
     const typeMdAsts = [
-      'Boolean',
-      'Number',
-      'String',
-      'Function',
       'Array',
-      'Object',
+      'Boolean',
       'Date',
+      'Function',
+      'Number',
+      'Object',
+      'Promise',
+      'String',
       'Uint8Array'
     ].reduce((typeMdAsts, type) => {
       typeMdAsts.push(typeToMdAst(type), typeToMdAst(type.toLowerCase()))

--- a/lib/typeJsdocAstToMdAst.test.js
+++ b/lib/typeJsdocAstToMdAst.test.js
@@ -73,7 +73,8 @@ t.test('typeJsdocAstToMdAst', t => {
       'Function',
       'Array',
       'Object',
-      'Date'
+      'Date',
+      'Uint8Array'
     ].reduce((typeMdAsts, type) => {
       typeMdAsts.push(typeToMdAst(type), typeToMdAst(type.toLowerCase()))
       return typeMdAsts

--- a/tap-snapshots/lib-typeJsdocAstToMdAst.test.js-TAP.test.js
+++ b/tap-snapshots/lib-typeJsdocAstToMdAst.test.js-TAP.test.js
@@ -644,6 +644,30 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
         }
       ]
     }
+  ],
+  [
+    {
+      "type": "link",
+      "url": "https://mdn.io/uint8array",
+      "children": [
+        {
+          "type": "text",
+          "value": "Uint8Array"
+        }
+      ]
+    }
+  ],
+  [
+    {
+      "type": "link",
+      "url": "https://mdn.io/uint8array",
+      "children": [
+        {
+          "type": "text",
+          "value": "uint8array"
+        }
+      ]
+    }
   ]
 ]
 `
@@ -676,6 +700,10 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
 [Date](https://mdn.io/date)
 
 [date](https://mdn.io/date)
+
+[Uint8Array](https://mdn.io/uint8array)
+
+[uint8array](https://mdn.io/uint8array)
 
 `
 

--- a/tap-snapshots/lib-typeJsdocAstToMdAst.test.js-TAP.test.js
+++ b/tap-snapshots/lib-typeJsdocAstToMdAst.test.js-TAP.test.js
@@ -480,6 +480,30 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
+      "url": "https://mdn.io/array",
+      "children": [
+        {
+          "type": "text",
+          "value": "Array"
+        }
+      ]
+    }
+  ],
+  [
+    {
+      "type": "link",
+      "url": "https://mdn.io/array",
+      "children": [
+        {
+          "type": "text",
+          "value": "array"
+        }
+      ]
+    }
+  ],
+  [
+    {
+      "type": "link",
       "url": "https://mdn.io/boolean",
       "children": [
         {
@@ -504,11 +528,11 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/number",
+      "url": "https://mdn.io/date",
       "children": [
         {
           "type": "text",
-          "value": "Number"
+          "value": "Date"
         }
       ]
     }
@@ -516,35 +540,11 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/number",
+      "url": "https://mdn.io/date",
       "children": [
         {
           "type": "text",
-          "value": "number"
-        }
-      ]
-    }
-  ],
-  [
-    {
-      "type": "link",
-      "url": "https://mdn.io/string",
-      "children": [
-        {
-          "type": "text",
-          "value": "String"
-        }
-      ]
-    }
-  ],
-  [
-    {
-      "type": "link",
-      "url": "https://mdn.io/string",
-      "children": [
-        {
-          "type": "text",
-          "value": "string"
+          "value": "date"
         }
       ]
     }
@@ -576,11 +576,11 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/array",
+      "url": "https://mdn.io/number",
       "children": [
         {
           "type": "text",
-          "value": "Array"
+          "value": "Number"
         }
       ]
     }
@@ -588,11 +588,11 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/array",
+      "url": "https://mdn.io/number",
       "children": [
         {
           "type": "text",
-          "value": "array"
+          "value": "number"
         }
       ]
     }
@@ -624,11 +624,11 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/date",
+      "url": "https://mdn.io/promise",
       "children": [
         {
           "type": "text",
-          "value": "Date"
+          "value": "Promise"
         }
       ]
     }
@@ -636,11 +636,35 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
   [
     {
       "type": "link",
-      "url": "https://mdn.io/date",
+      "url": "https://mdn.io/promise",
       "children": [
         {
           "type": "text",
-          "value": "date"
+          "value": "promise"
+        }
+      ]
+    }
+  ],
+  [
+    {
+      "type": "link",
+      "url": "https://mdn.io/string",
+      "children": [
+        {
+          "type": "text",
+          "value": "String"
+        }
+      ]
+    }
+  ],
+  [
+    {
+      "type": "link",
+      "url": "https://mdn.io/string",
+      "children": [
+        {
+          "type": "text",
+          "value": "string"
         }
       ]
     }
@@ -673,33 +697,37 @@ exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression 
 `
 
 exports[`lib/typeJsdocAstToMdAst.test.js TAP typeJsdocAstToMdAst NameExpression types. > Markdown. 1`] = `
+[Array](https://mdn.io/array)
+
+[array](https://mdn.io/array)
+
 [Boolean](https://mdn.io/boolean)
 
 [boolean](https://mdn.io/boolean)
 
-[Number](https://mdn.io/number)
+[Date](https://mdn.io/date)
 
-[number](https://mdn.io/number)
-
-[String](https://mdn.io/string)
-
-[string](https://mdn.io/string)
+[date](https://mdn.io/date)
 
 [Function](https://mdn.io/function)
 
 [function](https://mdn.io/function)
 
-[Array](https://mdn.io/array)
+[Number](https://mdn.io/number)
 
-[array](https://mdn.io/array)
+[number](https://mdn.io/number)
 
 [Object](https://mdn.io/object)
 
 [object](https://mdn.io/object)
 
-[Date](https://mdn.io/date)
+[Promise](https://mdn.io/promise)
 
-[date](https://mdn.io/date)
+[promise](https://mdn.io/promise)
+
+[String](https://mdn.io/string)
+
+[string](https://mdn.io/string)
 
 [Uint8Array](https://mdn.io/uint8array)
 


### PR DESCRIPTION
1. Included the `Uint8Array` type link to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).

2. Alphabetized the order of types in the [switch](https://github.com/pur3miish/jsdoc-md/blob/mdast-types/lib/typeJsdocAstToMdAst.js#L113-L122).

3. Alphabetized the test order and added Promise type to [mdast-types.test.js](https://github.com/pur3miish/jsdoc-md/blob/mdast-types/lib/typeJsdocAstToMdAst.test.js#L70-L78)