### PR TITLE
Changed the behavior of the @example tag parsing to format as code

### DIFF
--- a/lib/membersToMdAst.js
+++ b/lib/membersToMdAst.js
@@ -275,12 +275,14 @@ const membersToMdAst = (members, depth = 1) => {
                 ]
               })
 
+            const result = /\s?```([a-z]+)\r?\n?/gi.exec(tag.description)
+
             mdast.children.push({
               type: 'paragraph',
               children: [
                 {
                   type: 'code',
-                  lang: 'javascript',
+                  lang: result ? result[1] : 'javascript',
                   value: (tag.description || '').replace(
                     /\s?```[a-z]*\r?\n?/gi,
                     ''

--- a/lib/membersToMdAst.js
+++ b/lib/membersToMdAst.js
@@ -276,8 +276,17 @@ const membersToMdAst = (members, depth = 1) => {
               })
 
             mdast.children.push({
-              type: 'blockquote',
-              children: mdToMdAst(tag.description, outlinedMembers)
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'code',
+                  lang: 'javascript',
+                  value: (tag.description || '').replace(
+                    /\s?```[a-z]*\r?\n?/gi,
+                    ''
+                  )
+                }
+              ]
             })
           })
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdoc-md",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A CLI to analyze source JSDoc and generate documentation under a given heading in a markdown file (such as readme.md).",
   "license": "MIT",
   "author": {
@@ -8,6 +8,9 @@
     "email": "me@jaydenseric.com",
     "url": "https://jaydenseric.com"
   },
+  "contributors": [
+    "David Nunez <arizonatribe@gmail.com>"
+  ],
   "repository": "github:jaydenseric/jsdoc-md",
   "homepage": "https://github.com/jaydenseric/jsdoc-md#readme",
   "bugs": "https://github.com/jaydenseric/jsdoc-md/issues",

--- a/tap-snapshots/lib-jsdocMd.test.js-TAP.test.js
+++ b/tap-snapshots/lib-jsdocMd.test.js-TAP.test.js
@@ -35,13 +35,13 @@ Description, here is a **bold** word.
 
 _Construct a new instance, here is a **bold** word._
 
-\`\`\`javascript
+\`\`\`js
 const b = new B()
 \`\`\`
 
 _Construct a new instance with options._
 
-\`\`\`javascript
+\`\`\`js
 const b = new B(true)
 \`\`\`
 

--- a/tap-snapshots/lib-jsdocMd.test.js-TAP.test.js
+++ b/tap-snapshots/lib-jsdocMd.test.js-TAP.test.js
@@ -35,15 +35,15 @@ Description, here is a **bold** word.
 
 _Construct a new instance, here is a **bold** word._
 
-> \`\`\`js
-> const b = new B()
-> \`\`\`
+\`\`\`javascript
+const b = new B()
+\`\`\`
 
 _Construct a new instance with options._
 
-> \`\`\`js
-> const b = new B(true)
-> \`\`\`
+\`\`\`javascript
+const b = new B(true)
+\`\`\`
 
 #### B static method d
 


### PR DESCRIPTION
Hi,

This is a very useful package and I've introduced it to the build scripts that my team is using for our JavaScript apps, but I ran into a snag with the way `@example` tags are parsed. Currently they are being translated to markdown's as [blockquotes](https://github.com/jaydenseric/jsdoc-md/blob/91fb99725874fbc86c2efa1142519996cc1b08bb/lib/membersToMdAst.js#L279) rather than as `code`. I see from your tests and from [areas of your own code](https://github.com/jaydenseric/jsdoc-md/blob/91fb99725874fbc86c2efa1142519996cc1b08bb/lib/jsdocMd.js#L18) that are are manually adding the backticks inside the `@example` tags to wrap the code content. This is a little bit non-standard (not that JSDoc standards are crystal clear to begin with) and creates a compatibility problems for us where we aren't able to use any normal JSDoc templates.

The tool we built allows users to also create JSDoc HTML templates and that pairs very nicely with the functionality of `jsdoc-md` that appends to a project's README. We currently have a list of nearly a dozen popular JSDoc templates to choose from (ie, tui, monami, docdash, braintree, jaguarjs, postman, bookshelf, better-docs, etc.) and all of them automatically pick up `@example` content and syntax highlight it as JavaScript _unless_ those backticks are wrapping the content manually. When they are, the example content renders looking like this (basically as one string literal inside a code block):

    ```javascript
    add(1, 2);
    // () => 3
    add(2, 2);
    // () => 4
    ```

I want to avoid too many adjustments to the way myself and my team write our JSDoc annotations that are different from the way they show up in most JavaScript libraries (difficult enough to encourage writing JavaScript documentation as it is).

Would you be willing to accept this PR to make it so `jsdoc-md` doesn't format code as blockquote or require those backticks to be added in manually? I added in a piece that should make this backwards compatible (it will just strip those backticks out of the `tag.description` when creating the example content.

Thanks!
